### PR TITLE
Bump boxcars to 0.7.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ classifier = [
 ]
 
 [dependencies]
-boxcars = "0.6.2"
+boxcars = "0.7.0-rc.1"
 serde_json = "1.0.47"
 
 [dependencies.pyo3]


### PR DESCRIPTION
Contains the quaternion fix and removal of bias from vector data. This is marked as an rc candidate just to make sure I didn't miss anything small that the carball devs identify.