### PR TITLE
Upgrade boxcars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ classifier = [
 ]
 
 [dependencies]
-boxcars = "0.8.1"
+boxcars = "0.8.2"
 serde_json = "1.0.52"
 
 [dependencies.pyo3]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 #[pyfunction]
 fn parse_replay<'p>(py: Python<'p>, data: &[u8]) -> PyResult<PyObject> {
     let replay = boxcars::ParserBuilder::new(data)
+        .must_parse_network_data()
         .on_error_check_crc()
         .parse()
         .map_err(to_py_error)?;


### PR DESCRIPTION
* Upgrade boxcars to 0.8.2
* Always parse network frames, raise an exception instead of returning None if there's an error.